### PR TITLE
Handle a case where an issue with no nodes breaks

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -79,7 +79,7 @@ runner.run = async () => {
 
 		// For now we just select the first element. This needs testing
 		const selector = issue.nodes.map(node => selectorToString(node.target)).join(', ');
-		const element = window.document.querySelector(selector);
+		const element = (issue.nodes.length ? window.document.querySelector(selector) : null);
 
 		return {
 			code: issue.id,

--- a/test/unit/lib/runner.test.js
+++ b/test/unit/lib/runner.test.js
@@ -40,6 +40,14 @@ describe('lib/runner', () => {
 							]
 						}
 					]
+				},
+				{
+					id: 'mock-id-no-nodes',
+					description: 'mock description no-nodes',
+					impact: 'mock impact no-nodes',
+					help: 'mock help no-nodes',
+					helpUrl: 'mock-help-url-no-nodes',
+					nodes: []
 				}
 			],
 			incomplete: [
@@ -155,6 +163,18 @@ describe('lib/runner', () => {
 						impact: 'mock impact 2',
 						help: 'mock help 2',
 						helpUrl: 'mock-help-url-2'
+					}
+				},
+				{
+					code: 'mock-id-no-nodes',
+					message: 'mock help no-nodes (mock-help-url-no-nodes)',
+					type: 'error',
+					element: null,
+					runnerExtras: {
+						description: 'mock description no-nodes',
+						impact: 'mock impact no-nodes',
+						help: 'mock help no-nodes',
+						helpUrl: 'mock-help-url-no-nodes'
 					}
 				},
 				{


### PR DESCRIPTION
Pa11y was exiting in the rare scenario when an aXe issue has no nodes.
This meant that we were attempting to select an element using an empty
string as a selector, which is invalid.

Now if there are no nodes for an issue, we set the issue element to
`null`, which is handled correctly by Pa11y.