### PR TITLE
Add whitelist of files to be published on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "test": "make ci"
   },
   "files": [
-    "/lib"
+    "lib"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   "main": "./lib/runner.js",
   "scripts": {
     "test": "make ci"
-  }
+  },
+  "files": [
+    "/lib"
+  ]
 }


### PR DESCRIPTION
This reduces the size of the package from 7.1 kB (20.8 kB unpacked) to 5.1 kB (13.7 kB unpacked).