### PR TITLE
Pass options to aXe

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -41,7 +41,8 @@ runner.run = async options => {
 	 */
 	async function runAxeCore() {
 		const result = await window.axe.run(
-			getAxeContext()
+			getAxeContext(),
+			getAxeOptions()
 		);
 		return [].concat(
 			...result.violations.map(processViolation),
@@ -57,6 +58,49 @@ runner.run = async options => {
 	 */
 	function getAxeContext() {
 		return options.rootElement || window.document;
+	}
+
+	/**
+	 * Get the proper options to pass to aXe, according to the specified Pa11y options, ready to be
+	 * used in axe.run().
+	 * @private
+	 * @returns {Object} Returns a configuration object.
+	 */
+	function getAxeOptions() {
+		const axeOptions = {};
+
+		if (options.standard) {
+			axeOptions.runOnly = pa11yStandardToAxe();
+		}
+
+		return axeOptions;
+	}
+
+	/**
+	 * Map the Pa11y standard option to the aXe runOnly option.
+	 * @private
+	 * @returns {{type: string, values: string[]}} Returns the aXe runOnly value.
+	 */
+	function pa11yStandardToAxe() {
+		switch (options.standard) {
+			case 'Section508':
+				return {
+					type: 'tags',
+					values: ['section508', 'best-practice']
+				};
+			case 'WCAG2A':
+				return {
+					type: 'tags',
+					values: ['wcag2a', 'wcag21a', 'best-practice']
+				};
+			case 'WCAG2AA':
+			case 'WCAG2AAA':
+			default:
+				return {
+					type: 'tags',
+					values: ['wcag2a', 'wcag21a', 'wcag2aa', 'wcag21aa', 'best-practice']
+				};
+		}
 	}
 
 	/**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -72,6 +72,9 @@ runner.run = async options => {
 		if (options.standard) {
 			axeOptions.runOnly = pa11yStandardToAxe();
 		}
+		if (Array.isArray(options.rules)) {
+			axeOptions.rules = pa11yRulesToAxe();
+		}
 
 		return axeOptions;
 	}
@@ -101,6 +104,16 @@ runner.run = async options => {
 					values: ['wcag2a', 'wcag21a', 'wcag2aa', 'wcag21aa', 'best-practice']
 				};
 		}
+	}
+
+	/**
+	 * Map the Pa11y rules option to the aXe rules option.
+	 * @returns {Object} Returns the aXe rules value.
+	 */
+	function pa11yRulesToAxe() {
+		const axeRules = {};
+		options.rules.forEach(rule => (axeRules[rule] = {enabled: true}));
+		return axeRules;
 	}
 
 	/**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -28,7 +28,7 @@ runner.scripts = [
  * @param {Object} pa11y - The Pa11y object, including helper methods.
  * @returns {Promise} Returns a promise which resolves with aXe issues.
  */
-runner.run = async () => {
+runner.run = async options => {
 
 	// Configure and run aXe
 	const results = await runAxeCore();
@@ -40,11 +40,23 @@ runner.run = async () => {
 	 * @returns {Promise} Returns a promise which resolves with aXe issues.
 	 */
 	async function runAxeCore() {
-		const result = await window.axe.run();
+		const result = await window.axe.run(
+			getAxeContext()
+		);
 		return [].concat(
 			...result.violations.map(processViolation),
 			...result.incomplete.map(processIncomplete)
 		);
+	}
+
+	/**
+	 * Get the proper context to pass to aXe, according to the specified Pa11y options. It can be an
+	 * HTML element or a CSS selector, ready to be used in axe.run().
+	 * @private
+	 * @returns {Node | string} Returns a context element
+	 */
+	function getAxeContext() {
+		return options.rootElement || window.document;
 	}
 
 	/**

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -64,7 +64,7 @@ runner.run = async options => {
 	 * Get the proper options to pass to aXe, according to the specified Pa11y options, ready to be
 	 * used in axe.run().
 	 * @private
-	 * @returns {Object} Returns a configuration object.
+	 * @returns {RunOptions} Returns a configuration object.
 	 */
 	function getAxeOptions() {
 		const axeOptions = {};
@@ -82,7 +82,7 @@ runner.run = async options => {
 	/**
 	 * Map the Pa11y standard option to the aXe runOnly option.
 	 * @private
-	 * @returns {{type: string, values: string[]}} Returns the aXe runOnly value.
+	 * @returns {RunOnly} Returns the aXe runOnly value.
 	 */
 	function pa11yStandardToAxe() {
 		switch (options.standard) {

--- a/test/unit/lib/runner.test.js
+++ b/test/unit/lib/runner.test.js
@@ -158,7 +158,8 @@ describe('lib/runner', () => {
 			assert.calledOnce(global.window.axe.run);
 			assert.calledWithExactly(
 				global.window.axe.run,
-				global.window.document
+				global.window.document,
+				{}
 			);
 		});
 
@@ -263,7 +264,49 @@ describe('lib/runner', () => {
 				it('sets the aXe context', () => {
 					assert.calledWithExactly(
 						global.window.axe.run,
-						cssSelector
+						cssSelector,
+						sinon.match.any
+					);
+				});
+			});
+
+			describe('standard', () => {
+				it('supports level A', async () => {
+					options.standard = 'WCAG2A';
+					await runner.run(options, pa11y);
+					assert.calledWithExactly(
+						global.window.axe.run,
+						sinon.match.any,
+						sinon.match.hasNested(
+							'runOnly.values',
+							['wcag2a', 'wcag21a', 'best-practice']
+						)
+					);
+				});
+
+				it('supports level AA', async () => {
+					options.standard = 'WCAG2AA';
+					await runner.run(options, pa11y);
+					assert.calledWithExactly(
+						global.window.axe.run,
+						sinon.match.any,
+						sinon.match.hasNested(
+							'runOnly.values',
+							['wcag2a', 'wcag21a', 'wcag2aa', 'wcag21aa', 'best-practice']
+						)
+					);
+				});
+
+				it('supports section 508', async () => {
+					options.standard = 'Section508';
+					await runner.run(options, pa11y);
+					assert.calledWithExactly(
+						global.window.axe.run,
+						sinon.match.any,
+						sinon.match.hasNested(
+							'runOnly.values',
+							['section508', 'best-practice']
+						)
 					);
 				});
 			});

--- a/test/unit/lib/runner.test.js
+++ b/test/unit/lib/runner.test.js
@@ -310,6 +310,24 @@ describe('lib/runner', () => {
 					);
 				});
 			});
+
+			describe('rules', () => {
+				beforeEach(async () => {
+					options.rules = ['color-contrast', 'autocomplete-valid'];
+					await runner.run(options, pa11y);
+				});
+
+				it('sets the aXe rules', () => {
+					assert.calledWithExactly(
+						global.window.axe.run,
+						sinon.match.any,
+						sinon.match.has('rules', {
+							'color-contrast': {enabled: true},
+							'autocomplete-valid': {enabled: true}
+						})
+					);
+				});
+			});
 		});
 
 		describe('when aXe errors', () => {

--- a/test/unit/lib/runner.test.js
+++ b/test/unit/lib/runner.test.js
@@ -156,7 +156,10 @@ describe('lib/runner', () => {
 
 		it('runs aXe', () => {
 			assert.calledOnce(global.window.axe.run);
-			assert.calledWithExactly(global.window.axe.run);
+			assert.calledWithExactly(
+				global.window.axe.run,
+				global.window.document
+			);
 		});
 
 		it('resolves with processed and normalised issues', () => {
@@ -246,6 +249,24 @@ describe('lib/runner', () => {
 					}
 				}
 			]);
+		});
+
+		describe('when passing the Pa11y option', () => {
+			describe('rootElement', () => {
+				const cssSelector = '#main';
+
+				beforeEach(async () => {
+					options.rootElement = cssSelector;
+					await runner.run(options, pa11y);
+				});
+
+				it('sets the aXe context', () => {
+					assert.calledWithExactly(
+						global.window.axe.run,
+						cssSelector
+					);
+				});
+			});
 		});
 
 		describe('when aXe errors', () => {


### PR DESCRIPTION
Some Pa11y rules are currently supported for the `htmlcs` but not for the `axe` runner. These commits aim to change this.

Particularly, support would be added for the following Pa11y configuration properties:

* [`rootElement`]
* [`standard`]
* [`rules`]

[`rootElement`]: https://github.com/pa11y/pa11y#rootelement-element
[`rules`]: https://github.com/pa11y/pa11y#rules-array
[`standard`]: https://github.com/pa11y/pa11y#standard-string