### PR TITLE
Removing references to Section 508

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -86,11 +86,6 @@ runner.run = async options => {
 	 */
 	function pa11yStandardToAxe() {
 		switch (options.standard) {
-			case 'Section508':
-				return {
-					type: 'tags',
-					values: ['section508', 'best-practice']
-				};
 			case 'WCAG2A':
 				return {
 					type: 'tags',

--- a/test/unit/lib/runner.test.js
+++ b/test/unit/lib/runner.test.js
@@ -296,19 +296,6 @@ describe('lib/runner', () => {
 						)
 					);
 				});
-
-				it('supports section 508', async () => {
-					options.standard = 'Section508';
-					await runner.run(options, pa11y);
-					assert.calledWithExactly(
-						global.window.axe.run,
-						sinon.match.any,
-						sinon.match.hasNested(
-							'runOnly.values',
-							['section508', 'best-practice']
-						)
-					);
-				});
 			});
 
 			describe('rules', () => {


### PR DESCRIPTION
If we're removing Section 508 from pa11y, it seems like it should also be removed here in pa11y-runner-axe. pa11y issue for reference: https://github.com/pa11y/pa11y/issues/528